### PR TITLE
Fix bug by adding conditional to render the average rating.

### DIFF
--- a/src/components/MovieDetails/MovieDetails.js
+++ b/src/components/MovieDetails/MovieDetails.js
@@ -94,7 +94,7 @@ class MovieDetails extends Component {
         <section className="movie-details">
           <section>
             <h1>{title}</h1>
-            <h3>Average rating: {average_rating.toFixed(1)}/10</h3>
+            <h3>Average rating: {average_rating && average_rating.toFixed(1)}/10</h3>
             <h3>{this.displayUserRatingConditional()}</h3>
           </section>
           <section>


### PR DESCRIPTION
## Type of change

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling- no new features
- [ ] Refactoring- no new features

## Detailed Description
- Fixed issue by adding a conditional to the average rating rendering. I think since the reload has to fetch the movies again, on load there is no average rating for a movie that matches the url. 

## Why is this change required? What problem does it solve?
- Fixes page break on reload of a movie details page. 

## Were there any challenges that arose while implementing this feature? If so, how were the addressed?

## Related Issues:
https://github.com/megan-venetianer/rancid-tomatillos/issues/18

## Files modified:
- src/components/MovieDetails/MovieDetails.js
